### PR TITLE
fix nginx log path, which was unreadable by container user

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,6 +1,6 @@
 worker_processes  auto;
 
-error_log  /var/log/error.log warn;
+error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;
 
 


### PR DESCRIPTION
Docker gives a container permissions error when trying to write to /var/log/error.log.  This likely occurs as the container no longer runs as root.  The new path is already symlinked to stderr, so it should be writeable by any user.
- I am still testing these changes in build.

A more complete fix would be to revert to running the container as root, but telling nginx to fork to "user".  The OSX beta client developers have decided to map host binds to the container USER uid:gid, so such a fix may not work well on Macs (bless the OSX developers)
Such is fix can be seen here https://github.com/wunderkraut/alpine-nginx-pagespeed/compare/master...james-nesbitt:better-user-limits?expand=1
