### PR TITLE
fix nginx permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,6 @@ RUN set -x && \
 ADD conf/nginx.conf /etc/nginx/nginx.conf
 
 VOLUME ["/var/log/nginx"]
-VOLUME ["/tmp"]
 
 # Little impact in this image
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,11 +112,11 @@ RUN set -x && \
 # Make our nginx.conf available on the container
 ADD conf/nginx.conf /etc/nginx/nginx.conf
 
-USER app
-
 VOLUME ["/var/log/nginx"]
+VOLUME ["/tmp"]
 
-WORKDIR /etc/nginx
+# Little impact in this image
+WORKDIR /app
 
 EXPOSE 80 443
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,8 +1,9 @@
 worker_processes  auto;
 
-error_log  /var/log/error.log warn;
+error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;
 
+user app app;
 
 events {
     worker_connections  1024;


### PR DESCRIPTION
Running the master container gives:

```
docker run --rm quay.io/wunder/alpine-nginx-pagespeed
2016/05/03 10:04:14 [emerg] 1#0: open() "/var/log/access.log" failed (13: Permission denied)
nginx: [emerg] open() "/var/log/access.log" failed (13: Permission denied)
```
- revert docker user change, nginx user set,
- fixed non linked log path

[tested with full build from scratch]
