### PR TITLE
Update mod-pagespeed download and folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,9 @@
 FROM quay.io/wunder/wunder-alpine-base
 MAINTAINER aleksi.johansson@wunder.io
 
-ENV NGINX_VERSION=1.9.15 \
-    PAGESPEED_VERSION=1.11.33.1 \
-    SOURCE_DIR=/tmp/src \
-    LIBPNG_LIB=libpng12 \
-    LIBPNG_VERSION=1.2.56
+# Based on https://github.com/pagespeed/ngx_pagespeed/issues/1181#issuecomment-250776751
 
-RUN set -x && \
-    apk --no-cache --update add \
+RUN apk --no-cache add \
         ca-certificates \
         libuuid \
         apr \
@@ -18,12 +13,14 @@ RUN set -x && \
         icu-libs \
         openssl \
         pcre \
-        zlib && \
-    apk --no-cache --update add -t .build-deps \
+        zlib
+RUN set -x && \
+    apk --no-cache add -t .build-deps \
         apache2-dev \
         apr-dev \
         apr-util-dev \
         build-base \
+        curl \
         icu-dev \
         libjpeg-turbo-dev \
         linux-headers \
@@ -31,47 +28,49 @@ RUN set -x && \
         openssl-dev \
         pcre-dev \
         python \
-        wget \
         zlib-dev && \
-    mkdir ${SOURCE_DIR} && \
-    cd ${SOURCE_DIR} && \
-    wget -O- https://dl.google.com/dl/page-speed/psol/${PAGESPEED_VERSION}.tar.gz | tar -zxv && \
-    wget -O- http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar -zxv && \
-    wget -O- ftp://ftp.simplesystems.org/pub/libpng/png/src/${LIBPNG_LIB}/libpng-${LIBPNG_VERSION}.tar.gz | tar -zxv && \
-    wget -O- https://github.com/pagespeed/ngx_pagespeed/archive/v${PAGESPEED_VERSION}-beta.tar.gz | tar -zxv && \
-    cd ${SOURCE_DIR}/libpng-${LIBPNG_VERSION} && \
+    # Build libpng:
+    # This sadly requires an old version of http://www.libpng.org/pub/png/libpng.html
+    LIBPNG_VERSION=1.2.56 && \
+    cd /tmp && \
+    curl -L http://prdownloads.sourceforge.net/libpng/libpng-${LIBPNG_VERSION}.tar.gz | tar -zx && \
+    cd /tmp/libpng-${LIBPNG_VERSION} && \
     ./configure --build=$CBUILD --host=$CHOST --prefix=/usr --enable-shared --with-libpng-compat && \
-    make && \
-    make install && \
-    cd ${SOURCE_DIR} && \
-    wget https://raw.githubusercontent.com/wunderkraut/alpine-nginx-pagespeed/master/patches/automatic_makefile.patch && \
-    wget https://raw.githubusercontent.com/wunderkraut/alpine-nginx-pagespeed/master/patches/libpng_cflags.patch && \
-    wget https://raw.githubusercontent.com/wunderkraut/alpine-nginx-pagespeed/master/patches/pthread_nonrecursive_np.patch && \
-    wget https://raw.githubusercontent.com/wunderkraut/alpine-nginx-pagespeed/master/patches/rename_c_symbols.patch && \
-    wget https://raw.githubusercontent.com/wunderkraut/alpine-nginx-pagespeed/master/patches/stack_trace_posix.patch && \
-    cd ${SOURCE_DIR}/psol && \
-    patch -p1 -i ${SOURCE_DIR}/automatic_makefile.patch && \
-    patch -p1 -i ${SOURCE_DIR}/libpng_cflags.patch && \
-    patch -p1 -i ${SOURCE_DIR}/pthread_nonrecursive_np.patch && \
-    patch -p1 -i ${SOURCE_DIR}/rename_c_symbols.patch && \
-    patch -p1 -i ${SOURCE_DIR}/stack_trace_posix.patch && \
+    make install V=0 && \
+    # Build PageSpeed:
+    # Check https://github.com/pagespeed/ngx_pagespeed/releases for the latest version
+    PAGESPEED_VERSION=1.11.33.3 && \
+    cd /tmp && \
+    curl -L https://dl.google.com/dl/linux/mod-pagespeed/tar/beta/mod-pagespeed-beta-${PAGESPEED_VERSION}-r0.tar.bz2 | tar -jx && \
+    curl -L https://github.com/pagespeed/ngx_pagespeed/archive/v${PAGESPEED_VERSION}-beta.tar.gz | tar -zx && \
+    cd /tmp/modpagespeed-${PAGESPEED_VERSION} && \
+    curl -L https://raw.githubusercontent.com/wunderkraut/alpine-nginx-pagespeed/master/patches/automatic_makefile.patch | patch -p1 && \
+    curl -L https://raw.githubusercontent.com/wunderkraut/alpine-nginx-pagespeed/master/patches/libpng_cflags.patch | patch -p1 && \
+    curl -L https://raw.githubusercontent.com/wunderkraut/alpine-nginx-pagespeed/master/patches/pthread_nonrecursive_np.patch | patch -p1 && \
+    curl -L https://raw.githubusercontent.com/wunderkraut/alpine-nginx-pagespeed/master/patches/rename_c_symbols.patch | patch -p1 && \
+    curl -L https://raw.githubusercontent.com/wunderkraut/alpine-nginx-pagespeed/master/patches/stack_trace_posix.patch | patch -p1 && \
     ./generate.sh -D use_system_libs=1 -D _GLIBCXX_USE_CXX11_ABI=0 -D use_system_icu=1 && \
-    cd ${SOURCE_DIR}/psol/src && \
-    make BUILDTYPE=Release CXXFLAGS=" -I/usr/include/apr-1 -I${SOURCE_DIR}/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" CFLAGS=" -I/usr/include/apr-1 -I${SOURCE_DIR}/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" && \
-    cd ${SOURCE_DIR}/psol/src/pagespeed/automatic/ && \
-    make psol BUILDTYPE=Release CXXFLAGS=" -I/usr/include/apr-1 -I${SOURCE_DIR}/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" CFLAGS=" -I/usr/include/apr-1 -I${SOURCE_DIR}/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" && \
-    mkdir -p ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol && \
-    mkdir -p ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/lib/Release/linux/x64 && \
-    mkdir -p ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/out/Release && \
-    cp -r ${SOURCE_DIR}/psol/src/out/Release/obj ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/out/Release/ && \
-    cp -r ${SOURCE_DIR}/psol/src/net ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
-    cp -r ${SOURCE_DIR}/psol/src/testing ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
-    cp -r ${SOURCE_DIR}/psol/src/pagespeed ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
-    cp -r ${SOURCE_DIR}/psol/src/third_party ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
-    cp -r ${SOURCE_DIR}/psol/src/tools ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
-    cp -r ${SOURCE_DIR}/psol/src/pagespeed/automatic/pagespeed_automatic.a ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/lib/Release/linux/x64 && \
-    cd ${SOURCE_DIR}/nginx-${NGINX_VERSION} && \
-    LD_LIBRARY_PATH=${SOURCE_DIR}/psol/usr/lib ./configure --with-ipv6 \
+    cd /tmp/modpagespeed-${PAGESPEED_VERSION}/src && \
+    make BUILDTYPE=Release CXXFLAGS=" -I/usr/include/apr-1 -I/tmp/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" CFLAGS=" -I/usr/include/apr-1 -I/tmp/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" && \
+    cd /tmp/modpagespeed-${PAGESPEED_VERSION}/src/pagespeed/automatic/ && \
+    make psol BUILDTYPE=Release CXXFLAGS=" -I/usr/include/apr-1 -I/tmp/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" CFLAGS=" -I/usr/include/apr-1 -I/tmp/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" && \
+    mkdir -p /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol && \
+    mkdir -p /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/lib/Release/linux/x64 && \
+    mkdir -p /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/out/Release && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/out/Release/obj /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/out/Release/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/net /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/testing /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/pagespeed /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/third_party /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/tools /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/pagespeed/automatic/pagespeed_automatic.a /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/lib/Release/linux/x64 && \
+    # Build Nginx with support for PageSpeed:
+    # Check http://nginx.org/en/download.html for the latest version.
+    NGINX_VERSION=1.10.1 && \
+    cd /tmp && \
+    curl -L http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar -zx && \
+    cd /tmp/nginx-${NGINX_VERSION} && \
+    LD_LIBRARY_PATH=/tmp/modpagespeed-${PAGESPEED_VERSION}/usr/lib ./configure --with-ipv6 \
         --prefix=/var/lib/nginx \
         --sbin-path=/usr/sbin \
         --modules-path=/usr/lib/nginx \
@@ -79,17 +78,16 @@ RUN set -x && \
         --with-http_gzip_static_module \
         --with-file-aio \
         --with-http_v2_module \
-        --with-http_realip_module \
         --without-http_autoindex_module \
         --without-http_browser_module \
         --without-http_geo_module \
+        --without-http_map_module \
         --without-http_memcached_module \
         --without-http_userid_module \
         --without-mail_pop3_module \
         --without-mail_imap_module \
         --without-mail_smtp_module \
         --without-http_split_clients_module \
-        --without-http_uwsgi_module \
         --without-http_scgi_module \
         --without-http_referer_module \
         --without-http_upstream_ip_hash_module \
@@ -98,16 +96,20 @@ RUN set -x && \
         --http-log-path=/var/log/nginx/access.log \
         --error-log-path=/var/log/nginx/error.log \
         --pid-path=/var/run/nginx.pid \
-        --add-module=${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta \
+        --add-module=/tmp/ngx_pagespeed-${PAGESPEED_VERSION}-beta \
         --with-cc-opt="-fPIC -I /usr/include/apr-1" \
-        --with-ld-opt="-luuid -lapr-1 -laprutil-1 -licudata -licuuc -L${SOURCE_DIR}/psol/usr/lib -lpng12 -lturbojpeg -ljpeg" && \
-    make && \
-    make install && \
+        --with-ld-opt="-luuid -lapr-1 -laprutil-1 -licudata -licuuc -L/tmp/modpagespeed-${PAGESPEED_VERSION}/usr/lib -lpng12 -lturbojpeg -ljpeg" && \
+    make install --silent && \
+    # Clean-up:
+    cd && \
     apk del .build-deps && \
     rm -rf /tmp/* && \
-    rm -rf /var/cache/apk/* && \
+    # forward request and error logs to docker log collector
     ln -sf /dev/stdout /var/log/nginx/access.log && \
-    ln -sf /dev/stderr /var/log/nginx/error.log
+    ln -sf /dev/stderr /var/log/nginx/error.log && \
+    # Make PageSpeed cache writabl:
+    mkdir -p /var/cache/ngx_pagespeed && \
+    chmod -R o+wr /var/cache/ngx_pagespeed
 
 # Make our nginx.conf available on the container
 ADD conf/nginx.conf /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/wunder/wunder-alpine-base
-MAINTAINER ilari.makela@wunderkraut.com
+MAINTAINER aleksi.johansson@wunder.io
 
 ENV NGINX_VERSION=1.9.15 \
     PAGESPEED_VERSION=1.11.33.1 \
@@ -35,7 +35,7 @@ RUN set -x && \
         zlib-dev && \
     mkdir ${SOURCE_DIR} && \
     cd ${SOURCE_DIR} && \
-    wget -O- https://dl.google.com/dl/linux/mod-pagespeed/tar/beta/mod-pagespeed-beta-${PAGESPEED_VERSION}-r0.tar.bz2 | tar -jxv && \
+    wget -O- https://dl.google.com/dl/page-speed/psol/${PAGESPEED_VERSION}.tar.gz | tar -zxv && \
     wget -O- http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar -zxv && \
     wget -O- ftp://ftp.simplesystems.org/pub/libpng/png/src/${LIBPNG_LIB}/libpng-${LIBPNG_VERSION}.tar.gz | tar -zxv && \
     wget -O- https://github.com/pagespeed/ngx_pagespeed/archive/v${PAGESPEED_VERSION}-beta.tar.gz | tar -zxv && \
@@ -44,34 +44,34 @@ RUN set -x && \
     make && \
     make install && \
     cd ${SOURCE_DIR} && \
-    wget https://raw.githubusercontent.com/iler/alpine-nginx-pagespeed/master/patches/automatic_makefile.patch && \
-    wget https://raw.githubusercontent.com/iler/alpine-nginx-pagespeed/master/patches/libpng_cflags.patch && \
-    wget https://raw.githubusercontent.com/iler/alpine-nginx-pagespeed/master/patches/pthread_nonrecursive_np.patch && \
-    wget https://raw.githubusercontent.com/iler/alpine-nginx-pagespeed/master/patches/rename_c_symbols.patch && \
-    wget https://raw.githubusercontent.com/iler/alpine-nginx-pagespeed/master/patches/stack_trace_posix.patch && \
-    cd ${SOURCE_DIR}/modpagespeed-${PAGESPEED_VERSION} && \
+    wget https://raw.githubusercontent.com/wunderkraut/alpine-nginx-pagespeed/master/patches/automatic_makefile.patch && \
+    wget https://raw.githubusercontent.com/wunderkraut/alpine-nginx-pagespeed/master/patches/libpng_cflags.patch && \
+    wget https://raw.githubusercontent.com/wunderkraut/alpine-nginx-pagespeed/master/patches/pthread_nonrecursive_np.patch && \
+    wget https://raw.githubusercontent.com/wunderkraut/alpine-nginx-pagespeed/master/patches/rename_c_symbols.patch && \
+    wget https://raw.githubusercontent.com/wunderkraut/alpine-nginx-pagespeed/master/patches/stack_trace_posix.patch && \
+    cd ${SOURCE_DIR}/psol && \
     patch -p1 -i ${SOURCE_DIR}/automatic_makefile.patch && \
     patch -p1 -i ${SOURCE_DIR}/libpng_cflags.patch && \
     patch -p1 -i ${SOURCE_DIR}/pthread_nonrecursive_np.patch && \
     patch -p1 -i ${SOURCE_DIR}/rename_c_symbols.patch && \
     patch -p1 -i ${SOURCE_DIR}/stack_trace_posix.patch && \
     ./generate.sh -D use_system_libs=1 -D _GLIBCXX_USE_CXX11_ABI=0 -D use_system_icu=1 && \
-    cd ${SOURCE_DIR}/modpagespeed-${PAGESPEED_VERSION}/src && \
+    cd ${SOURCE_DIR}/psol/src && \
     make BUILDTYPE=Release CXXFLAGS=" -I/usr/include/apr-1 -I${SOURCE_DIR}/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" CFLAGS=" -I/usr/include/apr-1 -I${SOURCE_DIR}/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" && \
-    cd ${SOURCE_DIR}/modpagespeed-${PAGESPEED_VERSION}/src/pagespeed/automatic/ && \
+    cd ${SOURCE_DIR}/psol/src/pagespeed/automatic/ && \
     make psol BUILDTYPE=Release CXXFLAGS=" -I/usr/include/apr-1 -I${SOURCE_DIR}/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" CFLAGS=" -I/usr/include/apr-1 -I${SOURCE_DIR}/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" && \
     mkdir -p ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol && \
     mkdir -p ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/lib/Release/linux/x64 && \
     mkdir -p ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/out/Release && \
-    cp -r ${SOURCE_DIR}/modpagespeed-${PAGESPEED_VERSION}/src/out/Release/obj ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/out/Release/ && \
-    cp -r ${SOURCE_DIR}/modpagespeed-${PAGESPEED_VERSION}/src/net ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
-    cp -r ${SOURCE_DIR}/modpagespeed-${PAGESPEED_VERSION}/src/testing ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
-    cp -r ${SOURCE_DIR}/modpagespeed-${PAGESPEED_VERSION}/src/pagespeed ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
-    cp -r ${SOURCE_DIR}/modpagespeed-${PAGESPEED_VERSION}/src/third_party ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
-    cp -r ${SOURCE_DIR}/modpagespeed-${PAGESPEED_VERSION}/src/tools ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
-    cp -r ${SOURCE_DIR}/modpagespeed-${PAGESPEED_VERSION}/src/pagespeed/automatic/pagespeed_automatic.a ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/lib/Release/linux/x64 && \
+    cp -r ${SOURCE_DIR}/psol/src/out/Release/obj ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/out/Release/ && \
+    cp -r ${SOURCE_DIR}/psol/src/net ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
+    cp -r ${SOURCE_DIR}/psol/src/testing ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
+    cp -r ${SOURCE_DIR}/psol/src/pagespeed ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
+    cp -r ${SOURCE_DIR}/psol/src/third_party ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
+    cp -r ${SOURCE_DIR}/psol/src/tools ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/include/ && \
+    cp -r ${SOURCE_DIR}/psol/src/pagespeed/automatic/pagespeed_automatic.a ${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/lib/Release/linux/x64 && \
     cd ${SOURCE_DIR}/nginx-${NGINX_VERSION} && \
-    LD_LIBRARY_PATH=${SOURCE_DIR}/modpagespeed-${PAGESPEED_VERSION}/usr/lib ./configure --with-ipv6 \
+    LD_LIBRARY_PATH=${SOURCE_DIR}/psol/usr/lib ./configure --with-ipv6 \
         --prefix=/var/lib/nginx \
         --sbin-path=/usr/sbin \
         --modules-path=/usr/lib/nginx \
@@ -100,7 +100,7 @@ RUN set -x && \
         --pid-path=/var/run/nginx.pid \
         --add-module=${SOURCE_DIR}/ngx_pagespeed-${PAGESPEED_VERSION}-beta \
         --with-cc-opt="-fPIC -I /usr/include/apr-1" \
-        --with-ld-opt="-luuid -lapr-1 -laprutil-1 -licudata -licuuc -L${SOURCE_DIR}/modpagespeed-${PAGESPEED_VERSION}/usr/lib -lpng12 -lturbojpeg -ljpeg" && \
+        --with-ld-opt="-luuid -lapr-1 -laprutil-1 -licudata -licuuc -L${SOURCE_DIR}/psol/usr/lib -lpng12 -lturbojpeg -ljpeg" && \
     make && \
     make install && \
     apk del .build-deps && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN set -x && \
     cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/pagespeed/automatic/pagespeed_automatic.a /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-beta/psol/lib/Release/linux/x64 && \
     # Build Nginx with support for PageSpeed:
     # Check http://nginx.org/en/download.html for the latest version.
-    NGINX_VERSION=1.10.1 && \
+    NGINX_VERSION=1.11.4 && \
     cd /tmp && \
     curl -L http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar -zx && \
     cd /tmp/nginx-${NGINX_VERSION} && \


### PR DESCRIPTION
This is not working yet and needs more work. It seems mod-pagespeed folder structure has changed (maybe other things too) which is causing our build to fail. Trying to get this setup according to Google's setup instructions https://developers.google.com/speed/pagespeed/module/build_ngx_pagespeed_from_source
